### PR TITLE
fix: make kylin valid in docker.sh

### DIFF
--- a/context/docker/rootfs/scripts/docker.sh
+++ b/context/docker/rootfs/scripts/docker.sh
@@ -54,7 +54,7 @@ if ! command_exists docker; then
   lsb_dist="$(echo "$lsb_dist" | tr '[:upper:]' '[:lower:]')"
   echo "current system is $lsb_dist"
   case "$lsb_dist" in
-    ubuntu|deepin|debian|raspbian|kylin)
+    ubuntu|deepin|debian|raspbian)
     	cp ../etc/docker.service /lib/systemd/system/docker.service
     ;;
   	centos|rhel|ol|sles|kylin|neokylin)


### PR DESCRIPTION
Signed-off-by: Allen Sun <shlallen1990@gmail.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

in docker.sh, there are duplicated kylin os in docker installation. Therefore, we need to remove one.

The original source code is:
```
  case "$lsb_dist" in
    ubuntu|deepin|debian|raspbian)
    	cp ../etc/docker.service /lib/systemd/system/docker.service
    ;;
  	centos|rhel|ol|sles|kylin|neokylin)
			cp ../etc/docker.service /usr/lib/systemd/system/docker.service
		;;
```

So the second `kylin` will be never executed.

### Does this pull request fix one issue?
none
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
none

### Describe how to verify it
none

### Special notes for reviews
none