### PR TITLE
Deal with the problem that the latest coredns cannot be pulled

### DIFF
--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -11,13 +11,13 @@ jobs:
     permissions:
       issues: write
     steps:
-
+      - name: Check out code
+        uses: actions/checkout@v2
       - name: Auto build image
         id: autobuild
         run: |
           commentbody="${{github.event.comment.body}}"
           commentbody=$(echo $commentbody | sed "s/\/imagebuild//g")
-          sudo git clone https://github.com/sealerio/basefs.git && cd basefs
           sudo touch autobuild.log && sudo chmod 666 autobuild.log && sudo bash auto-build.sh --username="${{secrets.REGISTRY_USERNAME}}" --password="${{secrets.REGISTRY_PASSWORD}}" $commentbody > autobuild.log && cat autobuild.log
           echo "::set-output name=info::$(grep 'cri:' autobuild.log))"
 

--- a/context/rootfs/etc/kubeadm.yml
+++ b/context/rootfs/etc/kubeadm.yml
@@ -50,7 +50,7 @@ etcd:
     dataDir: ""
     extraArgs:
       listen-metrics-urls: http://0.0.0.0:2381
-imageRepository: k8s.gcr.io
+#imageRepository: k8s.gcr.io
 kind: ClusterConfiguration
 kubernetesVersion: v1.19.8
 networking:


### PR DESCRIPTION
checkout by action instead git clone
Deal with the problem that the latest coredns cannot be pulled

Signed-off-by: imdingtalk <dinhnhat9458@gmail.com>




### Describe what this PR does / why we need it
- Use checkout action for quick use and debugging after fork
- Deal with the problem that the latest coredns cannot be pulled

### Does this pull request fix one issue?

[#20](https://github.com/sealerio/basefs/issues/20#issuecomment-1247802010)  
The corresponding action failed to run
### Describe how you did it

Before building, you need to annotate the repository information to let kubeadm use the default repository

### Describe how to verify it

Create a new comment at #20


### Special notes for reviews
