### PR TITLE
registry expose the metrics port

### DIFF
--- a/context/rootfs/scripts/init-registry.sh
+++ b/context/rootfs/scripts/init-registry.sh
@@ -136,7 +136,9 @@ regArgs="-d --restart=always \
 -v $certs_dir:/certs \
 -v $VOLUME:/var/lib/registry \
 -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/$REGISTRY_DOMAIN.crt \
--e REGISTRY_HTTP_TLS_KEY=/certs/$REGISTRY_DOMAIN.key"
+-e REGISTRY_HTTP_TLS_KEY=/certs/$REGISTRY_DOMAIN.key \
+-e REGISTRY_HTTP_DEBUG_ADDR=0.0.0.0:5001 \
+-e REGISTRY_HTTP_DEBUG_PROMETHEUS_ENABLED=true"
 
 if [ -f "$config" ]; then
   sed -i "s/5000/$1/g" "$config"


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Registry will expose the metrics port. Users can get metrics from the port. It will not affect the use of registry.

### Does this pull request fix one issue?
No.
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
Add some envs.

### Describe how to verify it
curl http://${registryIP}:5001/metrics

### Special notes for reviews
